### PR TITLE
docker上のpostgresのportを変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
   app:
+    container_name: app
     build: .
     tty: true
     ports:
@@ -12,12 +13,13 @@ services:
     depends_on:
       - db
   db:
-    build: 
-      context: "."
-      dockerfile: "db.Dockerfile"
+    container_name: db
+    build:
+      context: .
+      dockerfile: db.Dockerfile
     restart: always
     ports:
-      - 5434:5433
+      - 5433:5432
     volumes:
       - ./db/postgres/init.d:/docker-entrypoint-initdb.d
       - ./db/postgres/data:/var/lib/postgresql/data
@@ -25,8 +27,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_INITDB_ARGS: "--encoding=UTF-8"
+      POSTGRES_INITDB_ARGS: '--encoding=UTF-8'
   pgadmin:
+    container_name: pgadmin
     image: dpage/pgadmin4
     restart: always
     ports:


### PR DESCRIPTION
## 概要
postgresのdockerコンテナ上のportを、デフォルトの`5432`に変更しました。

## 変更
[fix: docker上のpostgresのportを変更](https://github.com/nagayamajun/fillhome-api/pull/5/commits/f9b6aa76d72ef6f61a3295108c84906d91b4459a)

## 補足